### PR TITLE
Replace PHP CS Fixer ruleset

### DIFF
--- a/sets/default.php
+++ b/sets/default.php
@@ -14,7 +14,8 @@ return ECSConfig
     ::configure()
     ->withPhpCsFixerSets(
         php80Migration: true,
-        phpCsFixer: true,
+        per: true,
+        symfony: true,
     )
     ->withRules([
         FullyQualifiedStrictTypesFixer::class,

--- a/sets/default.php
+++ b/sets/default.php
@@ -14,7 +14,6 @@ return ECSConfig
     ::configure()
     ->withPhpCsFixerSets(
         php80Migration: true,
-        per: true,
         symfony: true,
     )
     ->withRules([


### PR DESCRIPTION
The [PHP CS Fixer rule set](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PhpCsFixer.rst) is customized for that project and contains several rules that are not common in the industry.

For example, it requires all tests to have the [`@covers` annotation](https://docs.phpunit.de/en/10.5/annotations.html#covers), which restricts the classes that are included in the coverage reports.

This PR aims to replace this set by the [Symfony rule set](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/Symfony.rst), on which the PHP CS Fixer rule set is based.

Its coding style is almost a standard in PHP, since Symfony is one of the largest projects and its libraries are widely used.

In addition, its rules are stable, avoiding unnecessary changes in our code base.