### PR TITLE
Remove `single_line_throw` rule

### DIFF
--- a/sets/default.php
+++ b/sets/default.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Exoticca\CodingStyle\Rules\DeclareStrictTypesFixer;
 use Exoticca\CodingStyle\Rules\InlineVarTagFixer;
 use Exoticca\CodingStyle\Rules\ValueObjectImportFixer;
+use PhpCsFixer\Fixer\FunctionNotation\SingleLineThrowFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -16,6 +17,9 @@ return ECSConfig
         php80Migration: true,
         phpCsFixer: true,
     )
+    ->withSkip([
+        SingleLineThrowFixer::class,
+    ])
     ->withRules([
         FullyQualifiedStrictTypesFixer::class,
         DeclareStrictTypesFixer::class,


### PR DESCRIPTION
The [Symfony rule set](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/Symfony.rst) includes a rule to [force throwing exceptions on a single line](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/function_notation/single_line_throw.rst).

This means that some like this:

```php
throw new BookingDocumentSlotAlreadyCreated(
    $bookingId,
    BookingDocumentType::passport(),
);
```

Becomes this:

```php
throw new BookingDocumentSlotAlreadyCreated($bookingId, BookingDocumentType::passport());
```

This PR proposes to skip that rule, since it is sometimes easier to read the code if we to spread the class construction over several lines, specially when the constructor has several parameters.