### PR TITLE
Add `blank_line_after_strict_types` rule

### DIFF
--- a/sets/default.php
+++ b/sets/default.php
@@ -7,6 +7,7 @@ use Exoticca\CodingStyle\Rules\InlineVarTagFixer;
 use Exoticca\CodingStyle\Rules\ValueObjectImportFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
+use Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option as ECS;
 
@@ -21,6 +22,7 @@ return ECSConfig
         DeclareStrictTypesFixer::class,
         InlineVarTagFixer::class,
         ValueObjectImportFixer::class,
+        BlankLineAfterStrictTypesFixer::class,
     ])
     ->withConfiguredRule(
         GlobalNamespaceImportFixer::class,


### PR DESCRIPTION
This PR add a simple [rule](https://github.com/symplify/coding-standard?tab=readme-ov-file#blanklineafterstricttypesfixer) to add an empty line between the strict types declaration and the namespace.

With this rule, this code:

```php
declare(strict_types=1);
namespace Exoticca\Adiona\Adiona\Cities\City\Domain;
```

becomes:

```php
declare(strict_types=1);

namespace Exoticca\Adiona\Adiona\Cities\City\Domain;
```