### PR TITLE
Add `standalone_line_promoted_property` rule

### DIFF
--- a/sets/default.php
+++ b/sets/default.php
@@ -7,6 +7,7 @@ use Exoticca\CodingStyle\Rules\InlineVarTagFixer;
 use Exoticca\CodingStyle\Rules\ValueObjectImportFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
+use Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option as ECS;
 
@@ -21,6 +22,7 @@ return ECSConfig
         DeclareStrictTypesFixer::class,
         InlineVarTagFixer::class,
         ValueObjectImportFixer::class,
+        StandaloneLinePromotedPropertyFixer::class,
     ])
     ->withConfiguredRule(
         GlobalNamespaceImportFixer::class,


### PR DESCRIPTION
This PR adds a [rule](https://github.com/symplify/coding-standard?tab=readme-ov-file#standalonelinepromotedpropertyfixer) to move promoted properties to standalone lines.

With this rule, this code:

```php
public function __construct(private CountryId $id, private CountryCode $isoCode) {}
```

becomes:

```php
public function __construct(
    private CountryId $id,
    private CountryCode $isoCode,
) {}
```

We usually distribute constructors with promoted properties over several lines, so this rule enforces this convection and guaranties cohesion.