### PR TITLE
Add `combine_consecutive_issets` and `combine_consecutive_unsets` rules

### DIFF
--- a/sets/default.php
+++ b/sets/default.php
@@ -7,6 +7,8 @@ use Exoticca\CodingStyle\Rules\InlineVarTagFixer;
 use Exoticca\CodingStyle\Rules\ValueObjectImportFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\CombineConsecutiveIssetsFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\CombineConsecutiveUnsetsFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option as ECS;
 
@@ -21,6 +23,8 @@ return ECSConfig
         DeclareStrictTypesFixer::class,
         InlineVarTagFixer::class,
         ValueObjectImportFixer::class,
+        CombineConsecutiveIssetsFixer::class,
+        CombineConsecutiveUnsetsFixer::class,
     ])
     ->withConfiguredRule(
         GlobalNamespaceImportFixer::class,


### PR DESCRIPTION
This PR recovers two rules to combine consecutive [issets](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/language_construct/combine_consecutive_issets.rst) and [unsets](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/language_construct/combine_consecutive_unsets.rst).

With these rules, this code:

```php
$a = isset($foo) && isset($bar);

unset($foo);
unset($bar);
```

becomes:

```php
$a = isset($foo, $bar;

unset($foo, $bar);
```

They were included in the [PHP CS Fixer ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PhpCsFixer.rst), so if we replace it by the [Symfony ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/Symfony.rst), it might be interesting to include them in our ruleset.