### PR TITLE
Add `explicit_string_variable` rule

### DIFF
--- a/sets/default.php
+++ b/sets/default.php
@@ -7,6 +7,7 @@ use Exoticca\CodingStyle\Rules\InlineVarTagFixer;
 use Exoticca\CodingStyle\Rules\ValueObjectImportFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
+use PhpCsFixer\Fixer\StringNotation\ExplicitStringVariableFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option as ECS;
 
@@ -21,6 +22,7 @@ return ECSConfig
         DeclareStrictTypesFixer::class,
         InlineVarTagFixer::class,
         ValueObjectImportFixer::class,
+        ExplicitStringVariableFixer::class,
     ])
     ->withConfiguredRule(
         GlobalNamespaceImportFixer::class,


### PR DESCRIPTION
This PR recovers a [rule](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/string_notation/explicit_string_variable.rst) to converts implicit variables into explicit ones in double-quoted strings or Heredoc syntax.

With this rule, this code:

```php
$a = "My name is $name.";
$b = "I live in $state->country.";
$c = "I have $farm[0] chickens.";
```

becomes:

```php
$a = "My name is {$name}.";
$b = "I live in {$state->country}.";
$c = "I have {$farm[0]} chickens.";
```

It was included in the [PHP CS Fixer ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PhpCsFixer.rst), so if we replace it by the [Symfony ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/Symfony.rst), it might be interesting to include it in our ruleset.