### PR TITLE
Add `method_chaining_indentation` rule

### DIFF
--- a/sets/default.php
+++ b/sets/default.php
@@ -7,6 +7,7 @@ use Exoticca\CodingStyle\Rules\InlineVarTagFixer;
 use Exoticca\CodingStyle\Rules\ValueObjectImportFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
+use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option as ECS;
 
@@ -21,6 +22,7 @@ return ECSConfig
         DeclareStrictTypesFixer::class,
         InlineVarTagFixer::class,
         ValueObjectImportFixer::class,
+        MethodChainingIndentationFixer::class,
     ])
     ->withConfiguredRule(
         GlobalNamespaceImportFixer::class,


### PR DESCRIPTION
This PR recovers a [rule](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/whitespace/method_chaining_indentation.rst) to indent chained methods consistently.

With this rule, this code:

```php
$user->setEmail('voff.web@gmail.com')
         ->setPassword('233434');
```

becomes:

```php
$user->setEmail('voff.web@gmail.com')
    ->setPassword('233434');
```

It was included in the [PHP CS Fixer ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PhpCsFixer.rst), so if we replace it by the [Symfony ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/Symfony.rst), it might be interesting to include it in our ruleset.