### PR TITLE
Add `multiline_comment_opening_closing` rule

### DIFF
--- a/sets/default.php
+++ b/sets/default.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Exoticca\CodingStyle\Rules\DeclareStrictTypesFixer;
 use Exoticca\CodingStyle\Rules\InlineVarTagFixer;
 use Exoticca\CodingStyle\Rules\ValueObjectImportFixer;
+use PhpCsFixer\Fixer\Comment\MultilineCommentOpeningClosingFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -21,6 +22,7 @@ return ECSConfig
         DeclareStrictTypesFixer::class,
         InlineVarTagFixer::class,
         ValueObjectImportFixer::class,
+        MultilineCommentOpeningClosingFixer::class,
     ])
     ->withConfiguredRule(
         GlobalNamespaceImportFixer::class,


### PR DESCRIPTION
This PR recovers a [rule](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/comment/multiline_comment_opening_closing.rst) to format multiline comments consistently.

With this rule, this code:

```php
/******
 * Multiline comment with arbitrary asterisks count
 ******/

/**\
 * Multiline comment that seems a DocBlock
 */

/**
 * DocBlock with arbitrary asterisk count at the end
 **/
```

becomes:

```php
/*
 * Multiline comment with arbitrary asterisks count
 */

/*\
 * Multiline comment that seems a DocBlock
 */

/**
 * DocBlock with arbitrary asterisk count at the end
 */
```

It was included in the [PHP CS Fixer ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PhpCsFixer.rst), so if we replace it by the [Symfony ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/Symfony.rst), it might be interesting to include it in our ruleset.